### PR TITLE
fixed -UseBasicParsing and wrote a test for it, a change to how New-AemApiAccessToken outputs the token, and documentation additions

### DIFF
--- a/Tests/AutoTaskEndpointManagement.tests.ps1
+++ b/Tests/AutoTaskEndpointManagement.tests.ps1
@@ -1,0 +1,16 @@
+Get-Module AutoTaskEndpointManagement | Remove-Module -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\bin\1.0.0.4\AutoTaskEndpointManagement\AutoTaskEndpointManagement.psd1
+. $PSScriptRoot\helpertest.ps1
+
+Describe 'Testing functions for use of -UseBasicParsing' {
+    $functions = Get-Command -Module AutoTaskEndpointManagement | Select-Object -ExpandProperty Name
+    foreach ($function in $functions) {
+        It "$function has the same count of Invoke-WebRequest as -UseBasicParsing" {
+            $functioncode = Get-Content Function:\$function
+            $functioncode = Remove-CommentsAndWhiteSpace -Scriptblock $functioncode
+            $CountInvoke = ([regex]::Matches($functioncode,"Invoke-WebRequest")).count
+            $CountUseBasic = ([regex]::Matches($functioncode,"-UseBasicParsing")).count
+            ($CountInvoke) -eq ($CountUseBasic) | Should -be $true
+        }
+    }
+}

--- a/Tests/helpertest.ps1
+++ b/Tests/helpertest.ps1
@@ -1,0 +1,151 @@
+function Remove-CommentsAndWhiteSpace
+{
+    # from https://www.madwithpowershell.com/2017/09/remove-comments-and-whitespace-from.html
+    # We are not restricting scriptblock type as Tokenize() can take several types
+    Param (
+    [parameter( ValueFromPipeline = $True )]
+    $Scriptblock
+    )
+
+    Begin
+    {
+    # Intialize collection
+    $Items = @()
+    }
+
+    Process
+    {
+    # Collect all of the inputs together
+    $Items += $Scriptblock
+    }
+
+    End
+    {
+    ## Process the script as a single unit
+
+    # Convert input to a single string if needed
+    $OldScript = $Items -join [environment]::NewLine
+
+    # If no work to do
+    # We're done
+    If ( -not $OldScript.Trim( " `n`r`t" ) ) { return }
+
+    # Use the PowerShell tokenizer to break the script into identified tokens
+    $Tokens = [System.Management.Automation.PSParser]::Tokenize( $OldScript, [ref]$Null )
+    # Strip out the Comments, but not useful comments
+    # (Bug: This will break comment-based help that uses leading # instead of multiline <#,
+    # because only the headings will be left behind.)
+
+    $Tokens = $Tokens.ForEach{
+        If ( $_.Type -ne 'Comment' )
+            {
+            $_
+            }
+        Else
+            {
+            $CommentText = $_.Content.Substring( $_.Content.IndexOf( '#' ) + 1 )
+            $FirstInnerToken = [System.Management.Automation.PSParser]::Tokenize( $CommentText, [ref]$Null ) |
+                Where-Object { $_.Type -ne 'NewLine' } |
+                Select-Object -First 1
+            If ( $FirstInnerToken.Content -in $AllowedComments )
+                {
+                $_
+                }
+            } }
+
+    # Initialize script string
+    $NewScriptText = ''
+    $SkipNext = $False
+
+    # If there are at least 2 tokens to process...
+    If ( $Tokens.Count -gt 1 )
+        {
+        # For each token (except the last one)...
+        ForEach ( $i in ( 0..($Tokens.Count-2) ) )
+            {
+            # If token is not a line continuation and not a repeated new line or semicolon...
+            If (    -not $SkipNext -and
+                    $Tokens[$i  ].Type -ne 'LineContinuation' -and (
+                    $Tokens[$i  ].Type -notin ( 'NewLine', 'StatementSeparator' ) -or
+                    $Tokens[$i+1].Type -notin ( 'NewLine', 'StatementSeparator', 'GroupEnd' ) ) )
+                {
+                # Add Token to new script
+                # For string and variable, reference old script to include $ and quotes
+                If ( $Tokens[$i].Type -in ( 'String', 'Variable' ) )
+                    {
+                    $NewScriptText += $OldScript.Substring( $Tokens[$i].Start, $Tokens[$i].Length )
+                    }
+                Else
+                    {
+                    $NewScriptText += $Tokens[$i].Content
+                    }
+
+                # If the token does not never require a trailing space
+                # And the next token does not never require a leading space
+                # And this token and the next are on the same line
+                # And this token and the next had white space between them in the original...
+                If (    $Tokens[$i  ].Type -notin ( 'NewLine', 'GroupStart', 'StatementSeparator' ) -and
+                        $Tokens[$i+1].Type -notin ( 'NewLine', 'GroupEnd', 'StatementSeparator' ) -and
+                        $Tokens[$i].EndLine -eq $Tokens[$i+1].StartLine -and
+                        $Tokens[$i+1].StartColumn - $Tokens[$i].EndColumn -gt 0 )
+                    {
+                    # Add a space to new script
+                    $NewScriptText += ' '
+                    }
+
+                # If the next token is a new line or semicolon following
+                # an open parenthesis or curly brace, skip it
+                $SkipNext = $Tokens[$i].Type -eq 'GroupStart' -and $Tokens[$i+1].Type -in ( 'NewLine', 'StatementSeparator' )
+                }
+
+            # Else (Token is a line continuation or a repeated new line or semicolon)...
+            Else
+                {
+                # [Do not include it in the new script]
+
+                # If the next token is a new line or semicolon following
+                # an open parenthesis or curly brace, skip it
+                $SkipNext = $SkipNext -and $Tokens[$i+1].Type -in ( 'NewLine', 'StatementSeparator' )
+                }
+            }
+        }
+
+    # If there is a last token to process...
+    If ( $Tokens )
+        {
+        # Add last token to new script
+        # For string and variable, reference old script to include $ and quotes
+        If ( $Tokens[$i].Type -in ( 'String', 'Variable' ) )
+            {
+            $NewScriptText += $OldScript.Substring( $Tokens[-1].Start, $Tokens[-1].Length )
+            }
+        Else
+            {
+            $NewScriptText += $Tokens[-1].Content
+            }
+        }
+
+    # Trim any leading new lines from the new script
+    $NewScriptText = $NewScriptText.TrimStart( "`n`r;" )
+
+    # Return the new script as the same type as the input
+    If ( $Items.Count -eq 1 )
+        {
+        If ( $Items[0] -is [scriptblock] )
+            {
+            # Return single scriptblock
+            return [scriptblock]::Create( $NewScriptText )
+            }
+        Else
+            {
+            # Return single string
+            return $NewScriptText
+            }
+        }
+    Else
+        {
+        # Return array of strings
+        return $NewScriptText.Split( "`n`r", [System.StringSplitOptions]::RemoveEmptyEntries )
+        }
+    }
+}

--- a/bin/1.0.0.4/AutoTaskEndpointManagement/AutoTaskEndpointManagement.psm1
+++ b/bin/1.0.0.4/AutoTaskEndpointManagement/AutoTaskEndpointManagement.psm1
@@ -189,7 +189,7 @@ Function Find-AemSoftwareInstance {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webrequest = Invoke-WebRequest @params -ErrorAction Stop | ConvertFrom-Json
+                $webrequest = Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop | ConvertFrom-Json
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. The specific error message is: {1}" -f (Get-Date -Format s), $_.Exception.Message)
@@ -308,7 +308,7 @@ Function Get-AemDevices {
         If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
         Try {
-            $webResponse = (Invoke-WebRequest @params -ErrorAction Stop).Content
+            $webResponse = (Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop).Content
         }
         Catch {
             $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -342,7 +342,7 @@ Function Get-AemDevices {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webResponse = (Invoke-WebRequest @params).Content
+                $webResponse = (Invoke-WebRequest @params -UseBasicParsing).Content
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -425,7 +425,7 @@ Function Get-AemDevicesFromSite {
         If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
         Try {
-            $webResponse = (Invoke-WebRequest @params -ErrorAction Stop).Content
+            $webResponse = (Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop).Content
         }
         Catch {
             $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -452,7 +452,7 @@ Function Get-AemDevicesFromSite {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webResponse = (Invoke-WebRequest @params).Content
+                $webResponse = (Invoke-WebRequest @params -UseBasicParsing).Content
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -555,7 +555,7 @@ Function Get-AemSites {
         If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
         Try {
-            $webResponse = (Invoke-WebRequest @params -ErrorAction Stop).Content
+            $webResponse = (Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop).Content
         }
         Catch {
             $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -589,7 +589,7 @@ Function Get-AemSites {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webResponse = (Invoke-WebRequest @params).Content
+                $webResponse = (Invoke-WebRequest -UseBasicParsing @params).Content
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -702,7 +702,7 @@ Function Get-AemSoftwareList {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webResponse = Invoke-WebRequest @params -ErrorAction Stop | ConvertFrom-Json
+                $webResponse = Invoke-WebRequest -UseBasicParsing @params -ErrorAction Stop | ConvertFrom-Json
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. The specific error message is: {1}" -f (Get-Date -Format s), $_.Exception.Message)
@@ -784,7 +784,7 @@ Function Get-AemUsers {
         If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
         Try {
-            $webResponse = (Invoke-WebRequest @params -ErrorAction Stop).Content
+            $webResponse = (Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop).Content
         }
         Catch {
             $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -811,7 +811,7 @@ Function Get-AemUsers {
             If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
 
             Try {
-                $webResponse = (Invoke-WebRequest @params).Content
+                $webResponse = (Invoke-WebRequest -UseBasicParsing @params).Content
             }
             Catch {
                 $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
@@ -845,6 +845,8 @@ Function New-AemApiAccessToken {
                 - Added return.
                 - Fixed output bug. The -BlockLogging parameter was blocking all output.
                 - Updated white space.
+            V1.0.0.3 date: 27 October 2018 - by Konstantin Kaminskiy
+                - Adjusted returned data to include only the access token itself to increase ease of use
         .LINK
         .PARAMETER ApiKey
             Mandatory parameter. Represents the API key to AEM's REST API.
@@ -909,7 +911,7 @@ Function New-AemApiAccessToken {
 
     # Request access token.
     Try {
-        $webResponse = Invoke-WebRequest @params -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        $webResponse = Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop | Select-Object -ExpandProperty access_token
     }
     Catch {
         $message = ("{0}: Unexpected error generating an authorization token. To prevent errors, {1} will exit. The specific error message is: {2}" `

--- a/bin/1.0.0.4/AutoTaskEndpointManagement/AutoTaskEndpointManagement.psm1
+++ b/bin/1.0.0.4/AutoTaskEndpointManagement/AutoTaskEndpointManagement.psm1
@@ -247,6 +247,12 @@ Function Get-AemDevices {
             Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
         .PARAMETER BlockLogging
             When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .EXAMPLE
+            Get-AemDevices -AemAccessToken $token
+            This will return all devices. 
+        .EXAMPLE
+            Get-AemDevices -AemAccessToken $token -DeviceId $id
+            This will return the device matching the specified id.
     #>
     [CmdletBinding(DefaultParameterSetName = ’AllDevices’)]
     Param (
@@ -380,6 +386,9 @@ Function Get-AemDevicesFromSite {
             Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
         .PARAMETER BlockLogging
             When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .EXAMPLE
+            Get-AemDevicesFromSite -AemAccessToken $token -SiteUid $uid
+            This will get the devices for the specified site. 
     #>
     [CmdletBinding()]
     Param (
@@ -494,6 +503,9 @@ Function Get-AemSites {
             Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
         .PARAMETER BlockLogging
             When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .EXAMPLE
+            Get-AemSites -AemAccessToken $token
+            This will return all sites.
     #>
     [CmdletBinding(DefaultParameterSetName = ’AllSites’)]
     Param (
@@ -618,8 +630,21 @@ Function Get-AemSoftwareList {
             V1.0.0.1 date: 23 August 2018
                 - Updated output.
                 - Fixed bug in setting up the web request parameters.
-        .PARAMETER
+        .PARAMETER AemAccessToken
+            Mandatory parameter. Represents the token returned once successful authentication to the API is achieved. Use New-AemApiAccessToken to obtain the token.
+        .PARAMETER DeviceId
+            Device to get the software list for, by id. 
+        .PARAMETER DeviceUID
+            Device to get the software list for, by uid.
+        .PARAMETER ApiUrl
+            Default value is 'https://zinfandel-api.centrastage.net'. Represents the URL to AutoTask's AEM API, for the desired instance.
+        .PARAMETER EventLogSource
+            Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
+        .PARAMETER BlockLogging
+            When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
         .EXAMPLE
+            Get-AemSoftwareList -DeviceUid $uid -AemAccessToken $token
+            Get the list of software for the agent specified by the uid.
     #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     Param (
@@ -851,7 +876,7 @@ Function New-AemApiAccessToken {
         .PARAMETER ApiKey
             Mandatory parameter. Represents the API key to AEM's REST API.
         .PARAMETER ApiSecretKey
-                Mandatory parameter. Represents the API secret key to AEM's REST API.
+            Mandatory parameter. Represents the API secret key to AEM's REST API.
         .PARAMETER EventLogSource
             Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
         .PARAMETER ApiUrl
@@ -860,6 +885,9 @@ Function New-AemApiAccessToken {
             When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
         .EXAMPLE
             .\New-AemApiAccessToken -ApiKey XXXXXXXXXXXXXXXXXXXX -ApiSecretKey XXXXXXXXXXXXXXXXXXXX
+        .EXAMPLE
+            $token = New-AemApiAccessToken -ApiKey XXXXXXXXXXXXXXXXXXXX -ApiSecretKey XXXXXXXXXXXXXXXXXXXX
+            Store your token in a variable for later use and re-use. 
     #>
     [CmdletBinding()]
     param (


### PR DESCRIPTION
First commit does changes to the code:
-where I found Invoke-WebRequest I added -UseBasicParsing
-added a Pester test for above. I am not sure what files should actually be getting tested, please correct if needed. 
-the way New-AemApiAccessToken returned the token seemed not intuitive to me, I altered it to return just the token. 
-made changes to the documentation. Wherever I found examples or parameter definitions missing I added them. 