### PR TITLE
adding Set-AemDeviceUDF, Set-AemSiteDescription, and Get-AemDevice

### DIFF
--- a/AutoTaskEndpointManagement.psd1
+++ b/AutoTaskEndpointManagement.psd1
@@ -60,7 +60,7 @@
     # Functions to export from this module
     FunctionsToExport = 'Find-AemSoftwareInstance', 
     'Get-AemDevicesFromSite', 'Get-AemDevices', 'Get-AemSites', 'Get-AemSoftwareList', 'Get-AemUsers',
-    'New-AemApiAccessToken'
+    'New-AemApiAccessToken', 'Set-AemDeviceUDF'
 
     # Cmdlets to export from this module
     CmdletsToExport   = '*'

--- a/AutoTaskEndpointManagement.psd1
+++ b/AutoTaskEndpointManagement.psd1
@@ -60,7 +60,7 @@
     # Functions to export from this module
     FunctionsToExport = 'Find-AemSoftwareInstance', 
     'Get-AemDevicesFromSite', 'Get-AemDevices', 'Get-AemSites', 'Get-AemSoftwareList', 'Get-AemUsers',
-    'New-AemApiAccessToken', 'Set-AemDeviceUDF'
+    'New-AemApiAccessToken', 'Set-AemDeviceUDF', 'Set-AemSiteDescription'
 
     # Cmdlets to export from this module
     CmdletsToExport   = '*'

--- a/Public/Get-AemDevice-Function.ps1
+++ b/Public/Get-AemDevice-Function.ps1
@@ -1,0 +1,167 @@
+﻿Function Get-AemDevice {
+    <#
+        .DESCRIPTION
+            Retrieves either individual devices by ID or UID, or all devices from AutoTask Endpoint Management. 
+        .NOTES 
+            Author: Mike Hashemi
+            V1.0.0.0 date: 16 June 2018
+                - Initial release.
+            V1.0.0.1 date: 17 June 2018
+                - Fixed typo in help.
+                - Changed return to filter out duplicate devices based on the Id field.
+            V1.0.0.2 date: 17 June 2018
+                - Removed uniqueness filter from return statement.
+            V1.0.0.3 date: 16 August 2018
+                - Updated white space.
+            V1.0.0.4 date: 18 November 2018
+                - Konstantin Kaminskiy renamed to Get-AemDevice, added ability to get device by UID.
+        .PARAMETER AemAccessToken
+            Mandatory parameter. Represents the token returned once successful authentication to the API is achieved. Use New-AemApiAccessToken to obtain the token.
+        .PARAMETER DeviceId
+            Represents the ID number (e.g. 23423) of the desired device.
+        .PARAMETER DeviceUID
+            Represents the UID (31fcea20-3924-c976-0a59-52ec4a2bbf6f) of the desired device.
+        .PARAMETER All
+            Use this parameter to get all devices from Autotask Endpoint Management.
+        .PARAMETER ApiUrl
+            Default value is 'https://zinfandel-api.centrastage.net'. Represents the URL to AutoTask's AEM API, for the desired instance.
+        .PARAMETER EventLogSource
+            Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
+        .PARAMETER BlockLogging
+            When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .EXAMPLE
+            Get-AemDevice -AemAccessToken $token
+            This will return all devices. 
+        .EXAMPLE
+            Get-AemDevice -AemAccessToken $token -DeviceId $id
+            This will return the device matching the specified id.
+        .EXAMPLE
+            Get-AemDevice -AemAccessToken $token -DeviceUID $UID
+            This will return the device matching the specified UID.
+    #>
+    [CmdletBinding(DefaultParameterSetName = ’AllDevices’)]
+    Param (
+        [Parameter(Mandatory = $True, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'AllDevices')]
+        [Parameter(ParameterSetName = 'IDFilter')]
+        [Parameter(ParameterSetName = 'UIDFilter')]
+        [string]$AemAccessToken,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'IDFilter')]
+        [int]$DeviceId,
+        
+        [Parameter(Mandatory = $false, ParameterSetName = 'UIDFilter')]
+        [string]$DeviceUID,
+
+        [string]$ApiUrl = 'https://zinfandel-api.centrastage.net',
+
+        [string]$EventLogSource = 'AemPowerShellModule',
+
+        [switch]$BlockLogging
+    )
+
+    Begin {
+        If (-NOT($BlockLogging)) {
+            $return = Add-EventLogSource -EventLogSource $EventLogSource
+
+            If ($return -ne "Success") {
+                $message = ("{0}: Unable to add event source ({1}). No logging will be performed." -f (Get-Date -Format s), $EventLogSource)
+                Write-Host $message -ForegroundColor Yellow;
+
+                $BlockLogging = $True
+            }
+        }
+
+        $message = ("{0}: Beginning {1}." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+    }
+
+    Process {
+        Switch ($PsCmdlet.ParameterSetName) {
+            {$_ -in ("IDFilter", "AllDevices","UIDFilter")} {
+                # Define parameters for Invoke-WebRequest cmdlet.
+                $params = @{
+                    Uri         = '{0}/api{1}' -f $ApiUrl, "/v2/account/devices"
+                    Method      = 'GET'
+                    ContentType = 'application/json'
+                    Headers     = @{'Authorization' = 'Bearer {0}' -f $AemAccessToken}
+                }
+
+                $message = ("{0}: Updated `$params hash table. The values are:`n{1}." -f (Get-Date -Format s), (($params | Out-String) -split "`n"))
+                If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            }
+            "IDFilter" {
+                $params.set_item("Uri", "$(($params.Uri).TrimEnd("/account/devices")+"/device/id/$DeviceId")")
+
+                $message = ("{0}: Updated `$params hash table (Uri key). The values are:`n{1}." -f (Get-Date -Format s), (($params | Out-String) -split "`n"))
+                If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            }
+            "UIDFilter" {
+                $params.set_item("Uri", "$(($params.Uri).TrimEnd("/account/devices")+"/device/$DeviceUID")")
+
+                $message = ("{0}: Updated `$params hash table (Uri key). The values are:`n{1}." -f (Get-Date -Format s), (($params | Out-String) -split "`n"))
+                If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            }
+        }
+
+        # Make request.
+        $message = ("{0}: Making the first web request." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+
+        Try {
+            $webResponse = (Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop).Content
+        }
+        Catch {
+            $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
+                    -f (Get-Date -Format s), $MyInvocation.MyCommand, $_.Exception.Message)
+            If ($BlockLogging) {Write-Host $message -ForegroundColor Red} Else {Write-Host $message -ForegroundColor Red; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Error -Message $message -EventId 5417}
+
+            Return "Error"
+        }
+
+        Switch ($PsCmdlet.ParameterSetName) {
+            "AllDevices" {
+                $devices = ($webResponse | ConvertFrom-Json).devices
+            }
+            "IDFilter" {
+                $devices = ($webResponse | ConvertFrom-Json)
+            }
+            "UIDFilter" {
+                $devices = ($webResponse | ConvertFrom-Json)
+            }
+        }
+
+        While ((($webResponse | ConvertFrom-Json).pageDetails).nextPageUrl) {
+            $page = ((($webResponse | ConvertFrom-Json).pageDetails).nextPageUrl).Split("&")[1]
+            $resourcePath = "/v2/account/devices?$page"
+
+            $params = @{
+                Uri         = '{0}/api{1}' -f $ApiUrl, $resourcePath
+                Method      = 'GET'
+                ContentType = 'application/json'
+                Headers     = @{'Authorization'	= 'Bearer {0}' -f $AemAccessToken}
+            }
+
+            $message = ("{0}: Making web request for page {1}." -f (Get-Date -Format s), $page.TrimStart("page="))
+            If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+
+            Try {
+                $webResponse = (Invoke-WebRequest @params -UseBasicParsing).Content
+            }
+            Catch {
+                $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
+                        -f (Get-Date -Format s), $MyInvocation.MyCommand, $_.Exception.Message)
+                If ($BlockLogging) {Write-Host $message -ForegroundColor Red} Else {Write-Host $message -ForegroundColor Red; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Error -Message $message -EventId 5417}
+
+                Return "Error"
+            }
+
+            $message = ("{0}: Retrieved an additional {1} devices." -f (Get-Date -Format s), (($webResponse|ConvertFrom-Json).devices).count)
+            If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            
+            $devices += ($webResponse|ConvertFrom-Json).devices
+        }
+
+        Return $devices
+    }
+} #1.0.0.4

--- a/Public/Set-AemDeviceUDF-Function.ps1
+++ b/Public/Set-AemDeviceUDF-Function.ps1
@@ -1,0 +1,99 @@
+Function Set-AemDeviceUDF {
+    <#
+        .DESCRIPTION
+            Sets or appends to the user defined feilds of the device 
+        .NOTES 
+            Author: Konstantin Kaminskiy
+            V1.0.0.0 date: 5 November 2018
+                - Initial release.
+        .PARAMETER AemAccessToken
+            Mandatory parameter. Represents the token returned once successful authentication to the API is achieved. Use New-AemApiAccessToken to obtain the token.
+        .PARAMETER DeviceUid
+            Represents the UID number (e.g. 9fd7io7a-fe95-44k0-9cd1-fcc0vcbc7900) of the desired device.
+        .PARAMETER ApiUrl
+            Default value is 'https://zinfandel-api.centrastage.net'. Represents the URL to AutoTask's AEM API, for the desired instance.
+        .PARAMETER EventLogSource
+            Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
+        .PARAMETER BlockLogging
+            When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .PARAMETER UdfData
+            A hash table pairing the udfs and their intended values.
+        .EXAMPLE
+            $udfs = @{
+                'udf1' = "String One"
+                'udf2' = "String Two"
+            }
+            Set-AemDeviceUDF -AemAccessToken $token -DeviceUID $deviceUid -UdfData $udfs
+            This will set the udfs to the values provided in $udfs.
+        .EXAMPLE
+            $udfs = Get-AemDevices -AemAccessToken $token -DeviceId '764402' | Select-Object -ExpandProperty udf
+            $newudfs = @{'udf6' = "$($udfs.udf6) - This data should be added"}
+            Set-AemDeviceUDF -AemAccessToken $token -DeviceUid $uid -UdfData $newudfs -Verbose
+            This will append to the udfs for the device. 
+            
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $True)]
+        [string]$AemAccessToken,
+
+        [Parameter(Mandatory = $True)]
+        [string]$DeviceUid,
+
+        [Parameter(Mandatory = $True)]
+        [hashtable]$UdfData,
+
+        [string]$ApiUrl = 'https://zinfandel-api.centrastage.net',
+
+        [string]$EventLogSource = 'AemPowerShellModule',
+
+        [switch]$BlockLogging
+    )
+
+    Begin {
+        If (-NOT($BlockLogging)) {
+            $return = Add-EventLogSource -EventLogSource $EventLogSource
+    
+            If ($return -ne "Success") {
+                $message = ("{0}: Unable to add event source ({1}). No logging will be performed." -f (Get-Date -Format s), $EventLogSource)
+                Write-Host $message -ForegroundColor Yellow;
+
+                $BlockLogging = $True
+            }
+        }
+
+        $message = ("{0}: Beginning {1}." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+    }
+
+    Process {    
+    # Define parameters for Invoke-WebRequest cmdlet.
+    $params = @{
+        Uri         = '{0}/api{1}' -f $ApiUrl, "/v2/device/$DeviceUid/udf"
+        Method      = 'Post'
+        ContentType = 'application/json'
+        Headers     = @{'Authorization' = 'Bearer {0}' -f $AemAccessToken}
+        Body        = ($UdfData | ConvertTo-Json)
+    }
+
+    $message = ("{0}: Updated `$params hash table. The values are:`n{1}." -f (Get-Date -Format s), (($params | Out-String) -split "`n"))
+    If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            
+
+        # Make request.
+        $message = ("{0}: Making the web request." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+
+        Try {
+            Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop | Out-Null
+        }
+        Catch {
+            $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
+                    -f (Get-Date -Format s), $MyInvocation.MyCommand, $_.Exception.Message)
+            If ($BlockLogging) {Write-Host $message -ForegroundColor Red} Else {Write-Host $message -ForegroundColor Red; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Error -Message $message -EventId 5417}
+
+            Return "Error"
+        }
+
+    }
+} #1.0.0.0

--- a/Public/Set-AemDeviceUDF-Function.ps1
+++ b/Public/Set-AemDeviceUDF-Function.ps1
@@ -1,7 +1,7 @@
 Function Set-AemDeviceUDF {
     <#
         .DESCRIPTION
-            Sets or appends to the user defined feilds of the device 
+            Sets the user defined feilds of the device 
         .NOTES 
             Author: Konstantin Kaminskiy
             V1.0.0.0 date: 5 November 2018

--- a/Public/Set-AemSiteDescription-Function.ps1
+++ b/Public/Set-AemSiteDescription-Function.ps1
@@ -1,0 +1,94 @@
+Function Set-AemSiteDescription {
+    <#
+        .DESCRIPTION
+            Sets the description of the AEM site 
+        .NOTES 
+            Author: Konstantin Kaminskiy
+            V1.0.0.0 date: 14 November 2018
+                - Initial release.
+        .PARAMETER AemAccessToken
+            Mandatory parameter. Represents the token returned once successful authentication to the API is achieved. Use New-AemApiAccessToken to obtain the token.
+        .PARAMETER SiteUid
+            Represents the UID number (e.g. 9fd7io7a-fe95-44k0-9cd1-fcc0vcbc7900) of the desired site.
+        .PARAMETER ApiUrl
+            Default value is 'https://zinfandel-api.centrastage.net'. Represents the URL to AutoTask's AEM API, for the desired instance.
+        .PARAMETER EventLogSource
+            Default value is 'AemPowerShellModule'. This parameter is used to specify the event source, that script/modules will use for logging.
+        .PARAMETER BlockLogging
+            When this switch is included, the code will write output only to the host and will not attempt to write to the Event Log.
+        .PARAMETER Description
+            A string with the intended description of the site.
+        .EXAMPLE
+            Set-AemSiteDescription -AemAccessToken $token -SiteUID $SiteUid -Description "The one site to rule them all!"
+            This will set the site description to "The one site to rule them all!".
+            
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $True)]
+        [string]$AemAccessToken,
+
+        [Parameter(Mandatory = $True)]
+        [string]$SiteUid,
+
+        [Parameter(Mandatory = $True)]
+        [string]$Description,
+
+        [string]$ApiUrl = 'https://zinfandel-api.centrastage.net',
+
+        [string]$EventLogSource = 'AemPowerShellModule',
+
+        [switch]$BlockLogging
+    )
+
+    Begin {
+        If (-NOT($BlockLogging)) {
+            $return = Add-EventLogSource -EventLogSource $EventLogSource
+    
+            If ($return -ne "Success") {
+                $message = ("{0}: Unable to add event source ({1}). No logging will be performed." -f (Get-Date -Format s), $EventLogSource)
+                Write-Host $message -ForegroundColor Yellow;
+
+                $BlockLogging = $True
+            }
+        }
+
+        $message = ("{0}: Beginning {1}." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+    }
+
+    Process {    
+    # Define parameters for Invoke-WebRequest cmdlet.
+    $Description = @{"description" = "$description";
+                     "name" = (Get-AemSites -AemAccessToken $AemAccessToken -SiteUid $SiteUid -ApiUrl $ApiUrl | 
+                               Select-Object -ExpandProperty name) 
+                    } | ConvertTo-Json
+    $params = @{
+        Uri         = '{0}/api{1}' -f $ApiUrl, "/v2/site/$SiteUid"
+        Method      = 'Post'
+        ContentType = 'application/json'
+        Headers     = @{'Authorization' = 'Bearer {0}' -f $AemAccessToken}
+        Body        = "$Description"
+    }
+
+    $message = ("{0}: Updated `$params hash table. The values are:`n{1}." -f (Get-Date -Format s), (($params | Out-String) -split "`n"))
+    If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+            
+
+        # Make request.
+        $message = ("{0}: Making the web request." -f (Get-Date -Format s), $MyInvocation.MyCommand)
+        If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Information -Message $message -EventId 5417}
+
+        Try {
+            Invoke-WebRequest @params -UseBasicParsing -ErrorAction Stop | Out-Null
+        }
+        Catch {
+            $message = ("{0}: It appears that the web request failed. Check your credentials and try again. To prevent errors, {1} will exit. The specific error message is: {2}" `
+                    -f (Get-Date -Format s), $MyInvocation.MyCommand, $_.Exception.Message)
+            If ($BlockLogging) {Write-Host $message -ForegroundColor Red} Else {Write-Host $message -ForegroundColor Red; Write-EventLog -LogName Application -Source $eventLogSource -EntryType Error -Message $message -EventId 5417}
+
+            Return "Error"
+        }
+
+    }
+} #1.0.0.0

--- a/Tests/AutoTaskEndpointManagement.tests.ps1
+++ b/Tests/AutoTaskEndpointManagement.tests.ps1
@@ -1,5 +1,5 @@
 Get-Module AutoTaskEndpointManagement | Remove-Module -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\bin\1.0.0.4\AutoTaskEndpointManagement\AutoTaskEndpointManagement.psd1
+Import-Module $PSScriptRoot\..\bin\$(Get-ChildItem -Path $PSScriptRoot\..\bin | Select-Object -Last 1)\AutoTaskEndpointManagement\AutoTaskEndpointManagement.psd1
 . $PSScriptRoot\helpertest.ps1
 
 Describe 'Testing functions for use of -UseBasicParsing' {


### PR DESCRIPTION
Set-AemDeviceUDF is exactly as advertised, sets the UDFs for devices, accepts a hashtable for the UDFs. 

Get-AemDevice is your Get-AemDevices that now also accepts UID as a parameter, will make life easier because devices identify themselves by UID in local machine registry. Also renamed because singular of the noun is the PowerShell standard. Please decide if that is ok and add the function to be exported or merge into the existing function. 

Set-AemSiteDescription is as advertised, it sets the site description to the provided string. At some point it may make sense to do a general Set-AemSite function but right now description seemed to be the one field it made a lot of sense to have the ability to programmatically set. The addition of the site name is actually required per response from AEM staff on their forum, is unfortunately behind a login screen. 
https://success.autotask.net/t5/Datto-RMM/unable-to-find-site-when-attempting-to-update-site-description/m-p/40310/highlight/false#M10052